### PR TITLE
Add PHP 7.2 to test matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - 7.2
           - 7.3
           - 7.4
     env:


### PR DESCRIPTION
PHP 7.2 is still quite common, ensure we test our libraries on that version.